### PR TITLE
fix: title typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Workshop FE Staf Muda</title>
+    <title>Workshop FE Staff Muda</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This pull request includes a small change to the `index.html` file. The change corrects a typo in the title of the webpage.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L7-R7): Corrected the title from "Workshop FE Staf Muda" to "Workshop FE Staff Muda".